### PR TITLE
Fix incorrect argument name

### DIFF
--- a/src/main/java/com/aliyun/openservices/log/common/Chart.java
+++ b/src/main/java/com/aliyun/openservices/log/common/Chart.java
@@ -127,7 +127,7 @@ public class Chart implements Serializable {
 	
 	public Chart() {}
 	public Chart(String title, String type, String logstore, String topic, String query, String start, String end,
-			ArrayList<String> xAisKeys, ArrayList<String> yAxisKeys, long xPosition, long yPosition, long width,
+			ArrayList<String> xAxisKeys, ArrayList<String> yAxisKeys, long xPosition, long yPosition, long width,
 			long height, String displayName) {
 		super();
 		this.title = title;


### PR DESCRIPTION
Currently, when set the member variable ```xAxisKeys``` in constructor, we ignored the argument ```xAisKeys``` which  should be ```xAxisKeys```. 