### PR TITLE
Simplify converting OssShipperConfig to JSON object

### DIFF
--- a/src/main/java/com/aliyun/openservices/log/common/OssShipperConfig.java
+++ b/src/main/java/com/aliyun/openservices/log/common/OssShipperConfig.java
@@ -137,16 +137,7 @@ public class OssShipperConfig implements ShipperConfig {
 	}
 
 	public JSONObject GetJsonObj() {
-		JSONObject obj = new JSONObject();
-
-		if (storageDetail.getmStorageFormat().equals("parquet")) {
-			obj = ((OssShipperParquetStorageDetail)storageDetail).ToJsonObject();
-		} else if (storageDetail.getmStorageFormat().equals("csv")) {
-			obj = ((OssShipperCsvStorageDetail)storageDetail).ToJsonObject();
-		} else {
-			obj = ((OssShipperJsonStorageDetail)storageDetail).ToJsonObject();
-		}
-		
+		JSONObject obj = storageDetail.ToJsonObject();
 		obj.put("ossBucket", this.mOssBucket);
 		obj.put("ossPrefix", this.mOssPrefix);
 		obj.put("roleArn", this.mRoleArn);


### PR DESCRIPTION
Currently, when converting the object ```storageDetail``` to a ```JSON``` object, we cast it to the corresponding  class type based on it's storage format. However, what ever the actual class it is, we only need to call it's ```ToJsonObject``` method which is a abstract method in the base class. So we can simplify it as ```JSONObject obj = storageDetail.ToJsonObject();```. 