### PR TITLE
Move utf-8 encoding to a common method

### DIFF
--- a/src/main/java/com/aliyun/openservices/log/Client.java
+++ b/src/main/java/com/aliyun/openservices/log/Client.java
@@ -422,6 +422,27 @@ public class Client implements LogService {
 		return pattern.matcher(str).matches();
 	}
 
+	private static byte[] encodeToUtf8(String source) throws LogException {
+		try {
+			return source.getBytes(Consts.UTF_8_ENCODING);
+		} catch (UnsupportedEncodingException e) {
+			throw new LogException("EncodingException", e.getMessage(), "");
+		}
+	}
+
+	private static String encodeResponseBodyToUtf8String(ResponseMessage response, String requestId) throws LogException {
+		byte[] body = response.GetRawBody();
+		if (body == null) {
+			throw new LogException("BadResponse", "The response body is null", null, requestId);
+		}
+		try {
+			return new String(body, Consts.UTF_8_ENCODING);
+		} catch (UnsupportedEncodingException e) {
+			throw new LogException("BadResponse",
+					"The response is not valid utf-8 string: ", e, requestId);
+		}
+	}
+
 	public GetLogtailProfileResponse ExtractLogtailProfile(Map<String, String> resHeaders, JSONObject object) throws LogException {
 		try {
 			int count = object.getInt("count");
@@ -575,11 +596,9 @@ public class Client implements LogService {
 			String topic = request.GetTopic();
 			CodingUtils.assertParameterNotNull(topic, "topic");
 			String source = request.GetSource();
-			if (request.getContentType() != Consts.CONST_SLS_JSON) {
+			if (!Consts.CONST_SLS_JSON.equals(request.getContentType())) {
 				Logs.LogGroup.Builder logs = Logs.LogGroup.newBuilder();
-				if (topic != null) {
-					logs.setTopic(topic);
-				}
+				logs.setTopic(topic);
 				if (source == null || source.isEmpty()) {
 					logs.setSource(this.sourceIp);
 				} else {
@@ -617,9 +636,7 @@ public class Client implements LogService {
 				logBytes = logs.build().toByteArray();
 			} else {
 				JSONObject jsonObj = new JSONObject();
-				if (topic != null) {
-					jsonObj.put("__topic__", topic);
-				}
+				jsonObj.put("__topic__", topic);
 				if (source == null || source.isEmpty()) {
 					jsonObj.put("__source__", this.sourceIp);
 				} else {
@@ -649,11 +666,7 @@ public class Client implements LogService {
 				if (tagObj.size() > 0) {
 					jsonObj.put("__tags__", tagObj);
 				}
-				try {
-					logBytes = jsonObj.toString().getBytes("utf-8");
-				} catch (UnsupportedEncodingException e) {
-					throw new LogException("UnsupportedEncoding", e.getMessage(), "");
-				}
+				logBytes = encodeToUtf8(jsonObj.toString());
 			}
 		}
 		if (logBytes.length > Consts.CONST_MAX_PUT_SIZE) {
@@ -698,11 +711,10 @@ public class Client implements LogService {
 			resourceUri += "/shards/lb";
 		} else
 			resourceUri += "/shards/route?key=" + shardKey;
-		Map<String, String> urlParameter = new HashMap<String, String>();
-		urlParameter = request.GetAllParams();
+		Map<String, String> urlParameter = request.GetAllParams();
 		long cmp_size = logBytes.length;
 
-		
+
 		for (int i = 0; i < 2; i++) {
 			String server_ip = null;
 			ClientConnectionStatus connection_status = null;
@@ -817,18 +829,7 @@ public class Client implements LogService {
 	}
 	private com.alibaba.fastjson.JSONArray ParseResponseMessageToArrayWithFastJson(ResponseMessage response,
 			String requestId) throws LogException {
-		byte[] body = response.GetRawBody();
-		if (body == null) {
-			throw new LogException("BadResponse", "The response body is null",
-					null, requestId);
-		}
-		String returnStr;
-		try {
-			returnStr = new String(body, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("BadResponse",
-					"The response is not valid utf-8 string : ", e, requestId);
-		}
+		String returnStr = encodeResponseBodyToUtf8String(response, requestId);
 
 		try {
 			com.alibaba.fastjson.JSONArray array = com.alibaba.fastjson.JSONArray.parseArray(returnStr);
@@ -952,13 +953,13 @@ public class Client implements LogService {
 
 		JSONArray json_array = this.ParseResponseMessageToArray(response,
 				requestId);
-		ListTopicsResponse listTopicRespone = new ListTopicsResponse(resHeaders);
+		ListTopicsResponse listTopicResponse = new ListTopicsResponse(resHeaders);
 		List<String> string_array = new ArrayList<String>();
 		for (int index = 0; index < json_array.size(); index++) {
 			string_array.add(json_array.getString(index));
 		}
-		listTopicRespone.SetTopics(string_array);
-		return listTopicRespone;
+		listTopicResponse.SetTopics(string_array);
+		return listTopicResponse;
 
 	}
 
@@ -1393,14 +1394,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = config.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
-
+		byte[] body = encodeToUtf8(config.ToRequestString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		String resourceUri = "/configs";
@@ -1439,13 +1433,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = config.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(config.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -1662,13 +1650,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = group.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(group.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -1703,13 +1685,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = group.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(group.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -1902,11 +1878,11 @@ public class Client implements LogService {
 
 		JSONObject object = ParserResponseMessage(response, requestId);
 
-		return ExtructMachinesFromResponse(resHeaders, object);
+		return ExtractMachinesFromResponse(resHeaders, object);
 
 	}
 
-	private ListMachinesResponse ExtructMachinesFromResponse(
+	private ListMachinesResponse ExtractMachinesFromResponse(
 			Map<String, String> resHeaders, JSONObject dict)
 			throws LogException {
 
@@ -2188,14 +2164,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = acl.ToRequestString();
-
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(acl.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -2458,19 +2427,7 @@ public class Client implements LogService {
 
 	protected JSONObject ParserResponseMessage(ResponseMessage response,
 			String requestId) throws LogException {
-		byte[] body = response.GetRawBody();
-
-		if (body == null) {
-			throw new LogException("BadResponse", "The response body is null",
-					null, requestId);
-		}
-		String res;
-		try {
-			res = new String(body, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("BadResponse",
-					"The response is not valid utf-8 string : ", e, requestId);
-		}
+		String res = encodeResponseBodyToUtf8String(response, requestId);
 		try {
 			JSONObject object = JSONObject.fromObject(res);
 
@@ -2484,19 +2441,8 @@ public class Client implements LogService {
 	
 	protected com.alibaba.fastjson.JSONObject ParserResponseMessageWithFastJson(ResponseMessage response,
 			String requestId) throws LogException {
-		byte[] body = response.GetRawBody();
+		String res = encodeResponseBodyToUtf8String(response, requestId);
 
-		if (body == null) {
-			throw new LogException("BadResponse", "The response body is null",
-					null, requestId);
-		}
-		String res;
-		try {
-			res = new String(body, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("BadResponse",
-					"The response is not valid utf-8 string : ", e, requestId);
-		}
 		try {
 			com.alibaba.fastjson.JSONObject object = com.alibaba.fastjson.JSONObject.parseObject(res);
 
@@ -2510,19 +2456,7 @@ public class Client implements LogService {
 
 	private JSONArray ParseResponseMessageToArray(ResponseMessage response,
 			String requestId) throws LogException {
-		byte[] body = response.GetRawBody();
-		if (body == null) {
-			throw new LogException("BadResponse", "The response body is null",
-					null, requestId);
-		}
-		String returnStr;
-		try {
-			returnStr = new String(body, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("BadResponse",
-					"The response is not valid utf-8 string : ", e, requestId);
-		}
-
+		String returnStr = encodeResponseBodyToUtf8String(response, requestId);
 		try {
 			JsonConfig jsonConfig = new JsonConfig();
 			jsonConfig.setIgnoreDefaultExcludes(true);
@@ -2595,12 +2529,7 @@ public class Client implements LogService {
 	protected ResponseMessage SendData(String project, HttpMethod method,
 			String resourceUri, Map<String, String> parameters,
 			Map<String, String> headers, String requestBody) throws LogException {
-		byte[] body;
-		try {
-			body = requestBody.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(requestBody);
 		return SendData(project, method, resourceUri, parameters, headers, body);
 	}
 
@@ -2847,13 +2776,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = logStore.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(logStore.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -2926,13 +2849,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = logStore.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(logStore.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -3011,13 +2928,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-
-		try {
-			body = indexJsonString.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(indexJsonString);
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		StringBuilder resourceUriBuilder = new StringBuilder();
@@ -3058,14 +2969,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = index.ToRequestString();
-
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(index.ToRequestString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		StringBuilder resourceUriBuilder = new StringBuilder();
@@ -3094,12 +2998,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		try {
-			body = indexJsonString.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(indexJsonString);
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -3141,14 +3040,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = index.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
-
+		byte[] body = encodeToUtf8(index.ToRequestString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		StringBuilder resourceUriBuilder = new StringBuilder();
@@ -3314,12 +3206,7 @@ public class Client implements LogService {
 		json_body.put("targetType", shipConfig.GetShipperType());
 		json_body.put("targetConfiguration", shipConfig.GetJsonObj());
 
-		byte[] body = null;
-		try {
-			body = json_body.toString().getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(json_body.toString());
 		
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -3355,12 +3242,7 @@ public class Client implements LogService {
 		json_body.put("targetType", shipConfig.GetShipperType());
 		json_body.put("targetConfiguration", shipConfig.GetJsonObj());
 
-		byte[] body;
-		try {
-			body = json_body.toString().getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(json_body.toString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -3526,12 +3408,7 @@ public class Client implements LogService {
 		for (String task : taskList) {
 			array.add(task);
 		}
-		byte[] body;
-		try {
-			body = array.toString().getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(array.toString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -3585,13 +3462,8 @@ public class Client implements LogService {
 		CodingUtils.assertParameterNotNull(consumerGroup, "consumerGroup");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		byte[] body;
-		String bodyStr = consumerGroup.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(consumerGroup.ToRequestString());
+
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		String resourceUri = "/logstores/" + request.GetLogStore()
@@ -3613,7 +3485,6 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(logStore, "logstore");
 		CodingUtils.assertStringNotNullOrEmpty(consumerGroup, "consumerGroup");
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		byte[] body;
 		String bodyStr;
 		if (inOrder != null && timeoutInSec != null) {
 			bodyStr = "{\"order\":" + inOrder + ",\"timeout\":" + timeoutInSec
@@ -3623,11 +3494,8 @@ public class Client implements LogService {
 		} else {
 			bodyStr = "{\"timeout\":" + timeoutInSec + "}";
 		}
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(bodyStr);
+
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		String resourceUri = "/logstores/" + logStore + "/consumergroups/"
@@ -3761,13 +3629,7 @@ public class Client implements LogService {
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 		Map<String, String> urlParameter = request.GetAllParams();
 
-		byte[] body;
-		String bodyStr = request.GetRequestBody();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(request.GetRequestBody());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		ResponseMessage response = SendData(project, HttpMethod.POST,
@@ -3793,13 +3655,7 @@ public class Client implements LogService {
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 		Map<String, String> urlParameter = request.GetAllParams();
 
-		byte[] body;
-		String bodyStr = request.GetRequestBody();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(request.GetRequestBody());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		ArrayList<Integer> responseShards = new ArrayList<Integer>();
@@ -3878,12 +3734,7 @@ public class Client implements LogService {
 		json_body.put("projectName", project);
 		json_body.put("description", projectDescription);
 
-		byte[] body = null;
-		try {
-			body = json_body.toString().getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(json_body.toString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
@@ -3976,14 +3827,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		byte[] body;
-		String bodyStr = machineList.ToRequestString();
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
-
+		byte[] body = encodeToUtf8(machineList.ToRequestString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		StringBuilder resourceUriBuilder = new StringBuilder();
@@ -4518,13 +4362,8 @@ public class Client implements LogService {
 		EtlJob etlJob = request.getEtlJob();
 		CodingUtils.assertParameterNotNull(etlJob, "etlJob");
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		byte[] body;
-		String bodyStr = etlJob.toJsonString(true,true);
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(etlJob.toJsonString(true, true));
+
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 		String resourceUri = Consts.CONST_ETLJOB_URI;
 		Map<String, String> urlParameter = new HashMap<String, String>();
@@ -4557,13 +4396,8 @@ public class Client implements LogService {
 		CodingUtils.assertParameterNotNull(etlJob, "etlJob");
 		CodingUtils.assertStringNotNullOrEmpty(etlJob.getJobName(), "etlJobName");
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		byte[] body;
-		String bodyStr = etlJob.toJsonString(false,false);
-		try {
-			body = bodyStr.getBytes("utf-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new LogException("EncodingException", e.getMessage(), "");
-		}
+		byte[] body = encodeToUtf8(etlJob.toJsonString(false, false));
+
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 		String resourceUri = Consts.CONST_ETLJOB_URI+ "/" + etlJob.getJobName();
 		Map<String, String> urlParameter = new HashMap<String, String>();


### PR DESCRIPTION
Currently, we encoding request and response body to ```utf-8``` encoding in a lot of methods. We can move those common logic to a private method, even another ```Utils``` class if it's needed in the future. 