### PR TITLE
Remove redundant access modifier for interface

### DIFF
--- a/src/main/java/com/aliyun/openservices/log/Client.java
+++ b/src/main/java/com/aliyun/openservices/log/Client.java
@@ -514,8 +514,8 @@ public class Client implements LogService {
 
 	public GetLogtailProfileResponse ExtractLogtailProfile(Map<String, String> resHeaders, JSONObject object) throws LogException {
 		try {
-			int count = object.getInt("count");
-			int total = object.getInt("total");
+			int count = object.getInt(Consts.CONST_COUNT);
+			int total = object.getInt(Consts.CONST_TOTAL);
 			JSONArray array = object.getJSONArray("profile");
 			List<LogtailProfile> logtailProfiles = new ArrayList<LogtailProfile>();
 			for (int i = 0; i < array.size(); i++) {
@@ -1633,8 +1633,8 @@ public class Client implements LogService {
 
 			object = ParserResponseMessage(response, requestId);
 
-			int total = object.getInt("total");
-			int count = object.getInt("count");
+			int total = object.getInt(Consts.CONST_TOTAL);
+			int count = object.getInt(Consts.CONST_COUNT);
             List<String> configs = ExtractConfigs(object, requestId);
 
 			listConfigResponse = new ListConfigResponse(resHeaders, count,
@@ -1889,10 +1889,9 @@ public class Client implements LogService {
 	private ListMachinesResponse ExtractMachinesFromResponse(
 			Map<String, String> resHeaders, JSONObject dict)
 			throws LogException {
-
 		try {
-			int count = dict.getInt("count");
-			int total = dict.getInt("total");
+			int count = dict.getInt(Consts.CONST_COUNT);
+			int total = dict.getInt(Consts.CONST_TOTAL);
 			JSONArray array = dict.getJSONArray("machines");
 			List<Machine> machines = new ArrayList<Machine>();
 			for (int i = 0; i < array.size(); i++) {
@@ -2042,8 +2041,8 @@ public class Client implements LogService {
 
 			object = ParserResponseMessage(response, requestId);
 
-			int total = object.getInt("total");
-			int count = object.getInt("count");
+			int total = object.getInt(Consts.CONST_TOTAL);
+			int count = object.getInt(Consts.CONST_COUNT);
             List<String>  groups = ExtractMachineGroups(object, requestId);
 
 			listMachineGroupResponse = new ListMachineGroupResponse(resHeaders,
@@ -2269,8 +2268,8 @@ public class Client implements LogService {
             String requestId = GetRequestId(resHeaders);
 			object = ParserResponseMessage(response, requestId);
 
-			int total = object.getInt("total");
-			int count = object.getInt("count");
+			int total = object.getInt(Consts.CONST_TOTAL);
+			int count = object.getInt(Consts.CONST_COUNT);
             List<ACL> acls = ExtractACLs(object, requestId);
 
 			listACLResponse = new ListACLResponse(resHeaders, count, total,
@@ -3272,8 +3271,8 @@ public class Client implements LogService {
 
 		JSONObject object = ParserResponseMessage(response, requestId);
 
-		return new ListShipperResponse(resHeaders, ExtractJsonInteger("count",
-				object), ExtractJsonInteger("total", object), ExtractJsonArray(
+		return new ListShipperResponse(resHeaders, ExtractJsonInteger(Consts.CONST_COUNT,
+				object), ExtractJsonInteger(Consts.CONST_TOTAL, object), ExtractJsonArray(
 				"shipper", object));
 	}
 
@@ -3308,7 +3307,7 @@ public class Client implements LogService {
 		String requestId = GetRequestId(resHeaders);
 		JSONObject object = ParserResponseMessage(response, requestId);
 		return new GetShipperTasksResponse(resHeaders, ExtractJsonInteger(
-				"count", object), ExtractJsonInteger("total", object),
+				Consts.CONST_COUNT, object), ExtractJsonInteger(Consts.CONST_TOTAL, object),
 				ExtractTasksStatisTic(object), ExtractShipperTask(object));
 	}
 

--- a/src/main/java/com/aliyun/openservices/log/LogService.java
+++ b/src/main/java/com/aliyun/openservices/log/LogService.java
@@ -11,8 +11,6 @@ import com.aliyun.openservices.log.common.EtlMeta;
 import com.aliyun.openservices.log.common.Index;
 import com.aliyun.openservices.log.common.LogItem;
 import com.aliyun.openservices.log.common.LogStore;
-import com.aliyun.openservices.log.common.Logging;
-import com.aliyun.openservices.log.common.Logs;
 import com.aliyun.openservices.log.common.MachineGroup;
 import com.aliyun.openservices.log.common.MachineList;
 import com.aliyun.openservices.log.common.ShipperConfig;
@@ -214,8 +212,12 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore is empty
 	 */
-	public GetHistogramsResponse GetHistograms(String project, String logstore,
-			int from, int to, String topic, String query) throws LogException;
+    GetHistogramsResponse GetHistograms(String project,
+                                        String logstore,
+                                        int from,
+                                        int to,
+                                        String topic,
+                                        String query) throws LogException;
 
 	/**
 	 * Get The log status(histogram info) from log service server which match
@@ -230,8 +232,7 @@ public interface LogService {
 	 * @throws NullPointerException
 	 *             if required parameter is null
 	 */
-	public GetHistogramsResponse GetHistograms(GetHistogramsRequest request)
-			throws LogException;
+    GetHistogramsResponse GetHistograms(GetHistogramsRequest request) throws LogException;
 
 	/**
 	 * Get The sub set of logs data from log service server which match input
@@ -261,8 +262,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore is empty
 	 */
-	public GetLogsResponse GetLogs(String project, String logStore, int from,
-			int to, String topic, String query) throws LogException;
+	GetLogsResponse GetLogs(String project, String logStore, int from,
+							int to, String topic, String query) throws LogException;
 
 	/**
 	 * Get The sub set of logs data from log service server which match input
@@ -302,9 +303,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore is empty
 	 */
-	public GetLogsResponse GetLogs(String project, String logStore, int from,
-			int to, String topic, String query, int line, int offset,
-			boolean reverse) throws LogException;
+	GetLogsResponse GetLogs(String project, String logStore, int from,
+							int to, String topic, String query, int line, int offset,
+							boolean reverse) throws LogException;
 
 	/**
 	 * Get The sub set of logs data from log service server which match input
@@ -319,7 +320,7 @@ public interface LogService {
 	 * @throws LogException
 	 *             if any error happen when get the data from log service server
 	 */
-	public GetLogsResponse GetLogs(GetLogsRequest request) throws LogException;
+	GetLogsResponse GetLogs(GetLogsRequest request) throws LogException;
 
 
 	/**
@@ -338,7 +339,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore is empty
 	 */
-	public GetLogsResponse GetProjectLogs(String project,String query) throws  LogException;
+	GetLogsResponse GetProjectLogs(String project, String query) throws  LogException;
 
 
 	/**
@@ -353,7 +354,7 @@ public interface LogService {
 	 * @throws LogException
 	 *             if any error happen when get the data from log service server
 	 */
-	public GetLogsResponse GetProjectLogs(GetProjectLogsRequest request) throws  LogException;
+	GetLogsResponse GetProjectLogs(GetProjectLogsRequest request) throws  LogException;
 
 	/**
 	 * Get all the logstore for the user
@@ -379,8 +380,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore is empty
 	 */
-	public ListLogStoresResponse ListLogStores(String project, int offset,
-			int size, String logstoreName) throws LogException;
+	ListLogStoresResponse ListLogStores(String project, int offset,
+										int size, String logstoreName) throws LogException;
 
 	/**
 	 * Get all the logstore of a project
@@ -393,8 +394,7 @@ public interface LogService {
 	 * @throws NullPointerException
 	 *             if required parameter is null
 	 */
-	public ListLogStoresResponse ListLogStores(ListLogStoresRequest request)
-			throws LogException;
+	ListLogStoresResponse ListLogStores(ListLogStoresRequest request) throws LogException;
 
 	/**
 	 * Get the topics in the logtstore
@@ -416,8 +416,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore is empty
 	 */
-	public ListTopicsResponse ListTopics(String project, String logStore,
-			String token, int line) throws LogException;
+	ListTopicsResponse ListTopics(String project, String logStore,
+								  String token, int line) throws LogException;
 
 	/**
 	 * Get the topics in the logtstore
@@ -430,8 +430,7 @@ public interface LogService {
 	 * @throws NullPointerException
 	 *             if required parameter is null
 	 */
-	public ListTopicsResponse ListTopics(ListTopicsRequest request)
-			throws LogException;
+	ListTopicsResponse ListTopics(ListTopicsRequest request) throws LogException;
 
 	/**
 	 * Send Data to log service server
@@ -459,8 +458,8 @@ public interface LogService {
 	 *             if project or logstore is empty, or the logGroup log count
 	 *             exceed 4096, or the total data size exceed 5MB
 	 */
-	public PutLogsResponse PutLogs(String project, String logStore,
-			String topic, List<LogItem> logItems, String source)
+	PutLogsResponse PutLogs(String project, String logStore,
+							String topic, List<LogItem> logItems, String source)
 			throws LogException;
 
 	/**
@@ -489,9 +488,9 @@ public interface LogService {
 	 *             if project or logstore is empty, or the logGroup log count
 	 *             exceed 4096, or the total data size exceed 5MB
 	 */
-	public PutLogsResponse PutLogs(String project, String logStore,
-			String topic, List<LogItem> logItems, String source,
-			String shardHash) throws LogException;
+	PutLogsResponse PutLogs(String project, String logStore,
+							String topic, List<LogItem> logItems, String source,
+							String shardHash) throws LogException;
 	/**
 	 * Send Data to log service server
 	 *
@@ -508,7 +507,7 @@ public interface LogService {
 	 *             if project or logstore is empty, or the logGroup log count
 	 *             exceed 4096, or the total data size exceed 5MB
 	 */
-	public PutLogsResponse PutLogs(PutLogsRequest request) throws LogException;
+	PutLogsResponse PutLogs(PutLogsRequest request) throws LogException;
 
 	/**
 	 * Get cursor from log service server
@@ -531,8 +530,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logStore is empty
 	 */
-	public GetCursorResponse GetCursor(String project, String logStore,
-			int shardId, long fromTime) throws LogException;
+	GetCursorResponse GetCursor(String project, String logStore,
+								int shardId, long fromTime) throws LogException;
 
 	/**
 	 * Get cursor from log service server
@@ -555,8 +554,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string argument in request is empty
 	 */
-	public GetCursorResponse GetCursor(String project, String logStore,
-			int shardId, Date fromTime) throws LogException;
+	GetCursorResponse GetCursor(String project, String logStore,
+								int shardId, Date fromTime) throws LogException;
 
 	/**
 	 * Get cursor from log service server
@@ -579,8 +578,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string argument in request is empty
 	 */
-	public GetCursorResponse GetCursor(String project, String logStore,
-			int shardId, CursorMode mode) throws LogException;
+	GetCursorResponse GetCursor(String project, String logStore,
+								int shardId, CursorMode mode) throws LogException;
 
 	/**
 	 * Get cursor from log service server
@@ -597,8 +596,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string argument in request is empty
 	 */
-	public GetCursorResponse GetCursor(GetCursorRequest request)
-			throws LogException;
+	GetCursorResponse GetCursor(GetCursorRequest request) throws LogException;
 
 	/**
 	 * Get the receive time of the package according to the cursor
@@ -619,8 +617,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string argument in request is empty
 	 */
-	public GetCursorTimeResponse GetCursorTime(String project, String logStore,
-			int shardId, String cursor) throws LogException;
+	GetCursorTimeResponse GetCursorTime(String project, String logStore,
+										int shardId, String cursor) throws LogException;
 
 	/**
 	 * Get the receive time of the package according to the cursor
@@ -634,8 +632,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string argument in request is empty
 	 */
-	public GetCursorTimeResponse GetCursorTime(GetCursorTimeRequest request)
-			throws LogException;
+	GetCursorTimeResponse GetCursorTime(GetCursorTimeRequest request) throws LogException;
 	/**
 	 * Get the shards in the logtstore
 	 *
@@ -653,8 +650,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore is empty
 	 */
-	public ListShardResponse ListShard(String project, String logStore)
-			throws LogException;
+	ListShardResponse ListShard(String project, String logStore) throws LogException;
 
 	/**
 	 * Get the shards in the logtstore
@@ -671,8 +667,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore in request is empty
 	 */
-	public ListShardResponse ListShard(ListShardRequest request)
-			throws LogException;
+	ListShardResponse ListShard(ListShardRequest request) throws LogException;
 
 	/**
 	 * split a readwrite shard in the logtstore
@@ -695,8 +690,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore in request is empty
 	 */
-	public ListShardResponse SplitShard(String project, String logStore,
-			int shardId, String midHash) throws LogException;
+	ListShardResponse SplitShard(String project, String logStore,
+								 int shardId, String midHash) throws LogException;
 
 	/**
 	 * split a readwrite shard in the logtstore
@@ -713,8 +708,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore in request is empty
 	 */
-	public ListShardResponse SplitShard(SplitShardRequest request)
-			throws LogException;
+	ListShardResponse SplitShard(SplitShardRequest request) throws LogException;
 
 	/**
 	 * merge two readwrite shards in the logtstore
@@ -735,8 +729,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore in request is empty
 	 */
-	public ListShardResponse MergeShards(String project, String logStore,
-			int shardId) throws LogException;
+	ListShardResponse MergeShards(String project, String logStore, int shardId) throws LogException;
 
 	/**
 	 * merge two readwrite shards in the logtstore
@@ -753,8 +746,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore in request is empty
 	 */
-	public ListShardResponse MergeShards(MergeShardsRequest request)
-			throws LogException;
+	ListShardResponse MergeShards(MergeShardsRequest request) throws LogException;
 
 	/**
 	 * delete a readonly shard in the logtstore
@@ -775,8 +767,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore in request is empty
 	 */
-	public DeleteShardResponse DeleteShard(String project, String logStore,
-			int shardId) throws LogException;
+	DeleteShardResponse DeleteShard(String project, String logStore,
+									int shardId) throws LogException;
 
 	/**
 	 * delete a readonly shard in the logtstore
@@ -793,8 +785,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore in request is empty
 	 */
-	public DeleteShardResponse DeleteShard(DeleteShardRequest request)
-			throws LogException;
+	DeleteShardResponse DeleteShard(DeleteShardRequest request) throws LogException;
 
 	/**
 	 * Batch get log
@@ -819,8 +810,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore or cursor is empty
 	 */
-	public BatchGetLogResponse BatchGetLog(String project, String logStore,
-			int shardId, int count, String cursor) throws LogException;
+	BatchGetLogResponse BatchGetLog(String project, String logStore,
+									int shardId, int count, String cursor) throws LogException;
 
 	/**
 	 * Batch get log
@@ -836,7 +827,7 @@ public interface LogService {
 	 * @param cursor
 	 *            the cursor to batch get log
 	 *
-	 * @param end_cursor
+	 * @param endCursor
 	 * 			  the end cursor to batch get log
 	 *
 	 * @return batch get log response
@@ -848,8 +839,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore or cursor is empty
 	 */
-	public BatchGetLogResponse BatchGetLog(String project, String logStore,
-			int shardId, int count, String cursor, String end_cursor) throws LogException;
+	BatchGetLogResponse BatchGetLog(String project, String logStore,
+									int shardId, int count, String cursor, String endCursor)
+			throws LogException;
 
 	/**
 	 * Batch get log
@@ -866,8 +858,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project or logstore or cursor in request is empty
 	 */
-	public BatchGetLogResponse BatchGetLog(BatchGetLogRequest request)
-			throws LogException;
+	BatchGetLogResponse BatchGetLog(BatchGetLogRequest request) throws LogException;
 
 	/**
 	 * Create logtail config
@@ -886,8 +877,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateConfigResponse CreateConfig(String project, Config config)
-			throws LogException;
+	CreateConfigResponse CreateConfig(String project, Config config) throws LogException;
 
 	/**
 	 * Create logtail config
@@ -904,8 +894,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateConfigResponse CreateConfig(CreateConfigRequest request)
-			throws LogException;
+	CreateConfigResponse CreateConfig(CreateConfigRequest request) throws LogException;
 
 	/**
 	 * Update logtail config
@@ -924,8 +913,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateConfigResponse UpdateConfig(String project, Config config)
-			throws LogException;
+	UpdateConfigResponse UpdateConfig(String project, Config config) throws LogException;
 
 	/**
 	 * Update logtail config
@@ -942,8 +930,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateConfigResponse UpdateConfig(UpdateConfigRequest request)
-			throws LogException;
+	UpdateConfigResponse UpdateConfig(UpdateConfigRequest request) throws LogException;
 
 	/**
 	 * Get logtail config
@@ -963,8 +950,7 @@ public interface LogService {
 	 *             if configName is empty
 	 *
 	 */
-	public GetConfigResponse GetConfig(String project, String configName)
-			throws LogException;
+	GetConfigResponse GetConfig(String project, String configName) throws LogException;
 
 	/**
 	 * Get logtail config
@@ -981,8 +967,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetConfigResponse GetConfig(GetConfigRequest request)
-			throws LogException;
+	GetConfigResponse GetConfig(GetConfigRequest request) throws LogException;
 
 	/**
 	 * Delete logtail config
@@ -1002,8 +987,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteConfigResponse DeleteConfig(String project, String configName)
-			throws LogException;
+	DeleteConfigResponse DeleteConfig(String project, String configName) throws LogException;
 
 	/**
 	 * Delete logtail config
@@ -1020,8 +1004,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteConfigResponse DeleteConfig(DeleteConfigRequest request)
-			throws LogException;
+	DeleteConfigResponse DeleteConfig(DeleteConfigRequest request) throws LogException;
 
 	/**
 	 * List logtail configs
@@ -1037,7 +1020,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListConfigResponse ListConfig(String project) throws LogException;
+	ListConfigResponse ListConfig(String project) throws LogException;
 
 	/**
 	 * List logtail configs
@@ -1058,8 +1041,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListConfigResponse ListConfig(String project, int offSet, int size)
-			throws LogException;
+	ListConfigResponse ListConfig(String project, int offSet, int size) throws LogException;
 
 	/**
 	 * List logtail configs
@@ -1082,8 +1064,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListConfigResponse ListConfig(String project, String configName,
-			int offSet, int size) throws LogException;
+	ListConfigResponse ListConfig(String project, String configName,
+								  int offSet, int size) throws LogException;
 
 	/**
 	 * List logtail configs
@@ -1100,8 +1082,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListConfigResponse ListConfig(ListConfigRequest request)
-			throws LogException;
+	ListConfigResponse ListConfig(ListConfigRequest request) throws LogException;
 
 	/**
 	 * get applied config on a certain machine group
@@ -1121,8 +1102,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetAppliedConfigResponse GetAppliedConfig(String project,
-			String groupName) throws LogException;
+	GetAppliedConfigResponse GetAppliedConfig(String project, String groupName) throws LogException;
 
 	/**
 	 * get applied config on a certain machine group
@@ -1139,8 +1119,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetAppliedConfigResponse GetAppliedConfig(
-			GetAppliedConfigsRequest request) throws LogException;
+	GetAppliedConfigResponse GetAppliedConfig(GetAppliedConfigsRequest request) throws LogException;
 
 	/**
 	 * get applied machine group for a certain logtail config
@@ -1160,8 +1139,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetAppliedMachineGroupsResponse GetAppliedMachineGroups(
-			String project, String configName) throws LogException;
+	GetAppliedMachineGroupsResponse GetAppliedMachineGroups(String project, String configName)
+			throws LogException;
 
 	/**
 	 * get applied machine group for a certain logtail config
@@ -1178,8 +1157,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetAppliedMachineGroupsResponse GetAppliedMachineGroups(
-			GetAppliedMachineGroupRequest request) throws LogException;
+	GetAppliedMachineGroupsResponse GetAppliedMachineGroups(GetAppliedMachineGroupRequest request)
+			throws LogException;
 
 	/**
 	 * Create machine group
@@ -1198,8 +1177,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateMachineGroupResponse CreateMachineGroup(String project,
-			MachineGroup group) throws LogException;
+	CreateMachineGroupResponse CreateMachineGroup(String project, MachineGroup group)
+			throws LogException;
 
 	/**
 	 * Create machine group
@@ -1216,8 +1195,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateMachineGroupResponse CreateMachineGroup(
-			CreateMachineGroupRequest request) throws LogException;
+	CreateMachineGroupResponse CreateMachineGroup(CreateMachineGroupRequest request)
+			throws LogException;
 
 	/**
 	 * Update machine group
@@ -1236,8 +1215,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateMachineGroupResponse UpdateMachineGroup(String project,
-			MachineGroup group) throws LogException;
+	UpdateMachineGroupResponse UpdateMachineGroup(String project, MachineGroup group)
+			throws LogException;
 
 	/**
 	 * Update machine group
@@ -1254,8 +1233,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateMachineGroupResponse UpdateMachineGroup(
-			UpdateMachineGroupRequest request) throws LogException;
+	UpdateMachineGroupResponse UpdateMachineGroup(UpdateMachineGroupRequest request)
+			throws LogException;
 
 	/**
 	 * add machine into machine group
@@ -1276,9 +1255,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateMachineGroupMachineResponse AddMachineIntoMahineGroup(String project,
-			String groupName,
-			MachineList machineList) throws LogException;
+	UpdateMachineGroupMachineResponse AddMachineIntoMahineGroup(String project,
+																String groupName,
+																MachineList machineList)
+			throws LogException;
 
 	/**
 	 * add machine into machine group
@@ -1295,7 +1275,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateMachineGroupMachineResponse AddMachineIntoMachineGroup(
+	UpdateMachineGroupMachineResponse AddMachineIntoMachineGroup(
 			UpdateMachineGroupMachineRequest request) throws LogException;
 
 	/**
@@ -1317,9 +1297,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateMachineGroupMachineResponse DeleteMachineFromMachineGroup(String project,
-			String groupName,
-			MachineList machineList) throws LogException;
+	UpdateMachineGroupMachineResponse DeleteMachineFromMachineGroup(String project,
+																	String groupName,
+																	MachineList machineList)
+			throws LogException;
 
 	/**
 	 * delete machine into machine group
@@ -1336,7 +1317,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateMachineGroupMachineResponse DeleteMachineFromMachineGroup(
+	UpdateMachineGroupMachineResponse DeleteMachineFromMachineGroup(
 			UpdateMachineGroupMachineRequest request) throws LogException;
 
 	/**
@@ -1356,8 +1337,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetMachineGroupResponse GetMachineGroup(String project,
-			String groupName) throws LogException;
+	GetMachineGroupResponse GetMachineGroup(String project, String groupName) throws LogException;
 
 	/**
 	 * Get machine group
@@ -1374,8 +1354,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetMachineGroupResponse GetMachineGroup(
-			GetMachineGroupRequest request) throws LogException;
+	GetMachineGroupResponse GetMachineGroup(GetMachineGroupRequest request) throws LogException;
 
 	/**
 	 * approve machine group
@@ -1394,8 +1373,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ApproveMachineGroupResponse ApproveMachineGroup(String project,
-			String groupName) throws LogException;
+	ApproveMachineGroupResponse ApproveMachineGroup(String project, String groupName)
+			throws LogException;
 
 	/**
 	 * approve machine group
@@ -1412,8 +1391,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ApproveMachineGroupResponse ApproveMachineGroup(
-			ApproveMachineGroupRequest request) throws LogException;
+    ApproveMachineGroupResponse ApproveMachineGroup(ApproveMachineGroupRequest request)
+            throws LogException;
 
 	/**
 	 * Delete machine group
@@ -1432,8 +1411,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteMachineGroupResponse DeleteMachineGroup(String project,
-			String groupName) throws LogException;
+    DeleteMachineGroupResponse DeleteMachineGroup(String project, String groupName)
+            throws LogException;
 
 	/**
 	 * Delete machine group
@@ -1450,8 +1429,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteMachineGroupResponse DeleteMachineGroup(
-			DeleteMachineGroupRequest request) throws LogException;
+    DeleteMachineGroupResponse DeleteMachineGroup(DeleteMachineGroupRequest request)
+            throws LogException;
 
 	/**
 	 * List machine groups
@@ -1467,8 +1446,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListMachineGroupResponse ListMachineGroup(String project)
-			throws LogException;
+    ListMachineGroupResponse ListMachineGroup(String project) throws LogException;
 
 	/**
 	 * List the real machines in the machine group
@@ -1490,8 +1468,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListMachinesResponse ListMachines(String project,
-			String machineGroup, int offset, int size) throws LogException;
+    ListMachinesResponse ListMachines(String project, String machineGroup, int offset, int size)
+            throws LogException;
 
 	/**
 	 * List machine groups
@@ -1512,8 +1490,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListMachineGroupResponse ListMachineGroup(String project,
-			int offSet, int size) throws LogException;
+    ListMachineGroupResponse ListMachineGroup(String project, int offSet, int size)
+            throws LogException;
 
 	/**
 	 * List machine groups
@@ -1536,8 +1514,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListMachineGroupResponse ListMachineGroup(String project,
-			String groupName, int offSet, int size) throws LogException;
+    ListMachineGroupResponse ListMachineGroup(String project, String groupName,
+                                              int offSet, int size) throws LogException;
 
 	/**
 	 * List machine groups
@@ -1554,8 +1532,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListMachineGroupResponse ListMachineGroup(
-			ListMachineGroupRequest request) throws LogException;
+    ListMachineGroupResponse ListMachineGroup(ListMachineGroupRequest request) throws LogException;
 
 	/**
 	 * Apply config to machine group
@@ -1576,8 +1553,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ApplyConfigToMachineGroupResponse ApplyConfigToMachineGroup(
-			String project, String groupName, String configName)
+    ApplyConfigToMachineGroupResponse ApplyConfigToMachineGroup(String project,
+                                                                String groupName,
+                                                                String configName)
 			throws LogException;
 
 	/**
@@ -1595,8 +1573,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ApplyConfigToMachineGroupResponse ApplyConfigToMachineGroup(
-			ApplyConfigToMachineGroupRequest request) throws LogException;
+    ApplyConfigToMachineGroupResponse ApplyConfigToMachineGroup(
+            ApplyConfigToMachineGroupRequest request) throws LogException;
 
 	/**
 	 * Remove config from machine group
@@ -1617,8 +1595,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public RemoveConfigFromMachineGroupResponse RemoveConfigFromMachineGroup(
-			String project, String groupName, String configName)
+    RemoveConfigFromMachineGroupResponse RemoveConfigFromMachineGroup(
+            String project, String groupName, String configName)
 			throws LogException;
 
 	/**
@@ -1636,8 +1614,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public RemoveConfigFromMachineGroupResponse RemoveConfigFromMachineGroup(
-			RemoveConfigFromMachineGroupRequest request) throws LogException;
+    RemoveConfigFromMachineGroupResponse RemoveConfigFromMachineGroup(
+            RemoveConfigFromMachineGroupRequest request) throws LogException;
 
 	/**
 	 * Update project ACL
@@ -1656,8 +1634,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateACLResponse UpdateACL(String project, ACL acl)
-			throws LogException;
+    UpdateACLResponse UpdateACL(String project, ACL acl) throws LogException;
 
 	/**
 	 * update log sotre acl
@@ -1676,8 +1653,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateACLResponse UpdateACL(String project, String logStore, ACL acl)
-			throws LogException;
+    UpdateACLResponse UpdateACL(String project, String logStore, ACL acl) throws LogException;
 
 	/**
 	 * Update ACL
@@ -1694,8 +1670,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateACLResponse UpdateACL(UpdateACLRequest request)
-			throws LogException;
+    UpdateACLResponse UpdateACL(UpdateACLRequest request) throws LogException;
 
 	/**
 	 * List ACL
@@ -1711,7 +1686,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListACLResponse ListACL(String project) throws LogException;
+    ListACLResponse ListACL(String project) throws LogException;
 
 	/**
 	 * List ACL
@@ -1730,8 +1705,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListACLResponse ListACL(String project, String logStore)
-			throws LogException;
+    ListACLResponse ListACL(String project, String logStore) throws LogException;
 
 	/**
 	 * List ACL
@@ -1752,8 +1726,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListACLResponse ListACL(String project, int offSet, int size)
-			throws LogException;
+    ListACLResponse ListACL(String project, int offSet, int size) throws LogException;
 
 	/**
 	 * List ACL
@@ -1776,8 +1749,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListACLResponse ListACL(String project, String logStore, int offSet,
-			int size) throws LogException;
+    ListACLResponse ListACL(String project, String logStore, int offSet, int size)
+            throws LogException;
 
 	/**
 	 * List ACL
@@ -1794,7 +1767,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListACLResponse ListACL(ListACLRequest request) throws LogException;
+    ListACLResponse ListACL(ListACLRequest request) throws LogException;
 
 	/**
 	 * create a logstore in a project
@@ -1805,15 +1778,14 @@ public interface LogService {
 	 *            the config
 	 * @return the create log store response
 	 * @throws LogException
-	 *             if any error happen when creasting logstore
+	 *             if any error happen when creating logstore
 	 *
 	 * @throws NullPointerException
 	 *             if any parameter is null
 	 * @throws IllegalArgumentException
 	 *             if project is empty
 	 */
-	public CreateLogStoreResponse CreateLogStore(String project,
-			LogStore logStore) throws LogException;
+    CreateLogStoreResponse CreateLogStore(String project, LogStore logStore) throws LogException;
 
 	/**
 	 * create logstore
@@ -1822,15 +1794,14 @@ public interface LogService {
 	 *            logstore create request
 	 * @return the create log store response
 	 * @throws LogException
-	 *             if any error happen when creasting logstore
+	 *             if any error happen when creating logstore
 	 *
 	 * @throws NullPointerException
 	 *             if required parameter is null
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateLogStoreResponse CreateLogStore(CreateLogStoreRequest request)
-			throws LogException;
+    CreateLogStoreResponse CreateLogStore(CreateLogStoreRequest request) throws LogException;
 
 	/**
 	 * Update log store config
@@ -1848,8 +1819,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if project is empty
 	 */
-	public UpdateLogStoreResponse UpdateLogStore(String project,
-			LogStore logStore) throws LogException;
+    UpdateLogStoreResponse UpdateLogStore(String project, LogStore logStore) throws LogException;
 
 	/**
 	 * Update logstore config
@@ -1865,8 +1835,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateLogStoreResponse UpdateLogStore(UpdateLogStoreRequest request)
-			throws LogException;
+    UpdateLogStoreResponse UpdateLogStore(UpdateLogStoreRequest request) throws LogException;
 
 	/**
 	 * Delete the logstore
@@ -1884,8 +1853,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if an param is empty
 	 */
-	public DeleteLogStoreResponse DeleteLogStore(String project,
-			String logStoreName) throws LogException;
+    DeleteLogStoreResponse DeleteLogStore(String project, String logStoreName) throws LogException;
 
 	/**
 	 * Delete logstore
@@ -1900,8 +1868,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteLogStoreResponse DeleteLogStore(DeleteLogStoreRequest request)
-			throws LogException;
+    DeleteLogStoreResponse DeleteLogStore(DeleteLogStoreRequest request) throws LogException;
 
 	/**
 	 * Get the logstore config
@@ -1919,8 +1886,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any parameter is empty
 	 */
-	public GetLogStoreResponse GetLogStore(String project, String logStoreName)
-			throws LogException;
+    GetLogStoreResponse GetLogStore(String project, String logStoreName) throws LogException;
 
 	/**
 	 * get the logstore config
@@ -1936,8 +1902,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetLogStoreResponse GetLogStore(GetLogStoreRequest request)
-			throws LogException;
+    GetLogStoreResponse GetLogStore(GetLogStoreRequest request) throws LogException;
 
 	/**
 	 * create logstore index
@@ -1958,8 +1923,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string paramter is empty
 	 */
-	public CreateIndexResponse CreateIndex(String project, String logStore,
-										   String indexJsonString) throws LogException;
+    CreateIndexResponse CreateIndex(String project, String logStore,
+                                    String indexJsonString) throws LogException;
 
 	/**
 	 * create logstore index
@@ -1978,10 +1943,10 @@ public interface LogService {
 	 *             if the request is null
 	 *
 	 * @throws IllegalArgumentException
-	 *             if any string paramter is empty
+	 *             if any string parameter is empty
 	 */
-	public CreateIndexResponse CreateIndex(String project, String logStore,
-			Index index) throws LogException;
+    CreateIndexResponse CreateIndex(String project, String logStore, Index index)
+            throws LogException;
 
 	/**
 	 * create logstore index
@@ -1997,8 +1962,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateIndexResponse CreateIndex(CreateIndexRequest request)
-			throws LogException;
+    CreateIndexResponse CreateIndex(CreateIndexRequest request) throws LogException;
 
 	/**
 	 * Update logstore index config
@@ -2019,8 +1983,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string parameter is empty
 	 */
-	public UpdateIndexResponse UpdateIndex(String project, String logStore,
-										   String indexJsonString) throws LogException;
+    UpdateIndexResponse UpdateIndex(String project, String logStore,
+                                    String indexJsonString) throws LogException;
 
 	/**
 	 * Update logstore index config
@@ -2041,8 +2005,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string parameter is empty
 	 */
-	public UpdateIndexResponse UpdateIndex(String project, String logStore,
-			Index index) throws LogException;
+    UpdateIndexResponse UpdateIndex(String project, String logStore, Index index)
+            throws LogException;
 
 	/**
 	 * update logstore index config
@@ -2058,8 +2022,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateIndexResponse UpdateIndex(UpdateIndexRequest request)
-			throws LogException;
+    UpdateIndexResponse UpdateIndex(UpdateIndexRequest request) throws LogException;
 
 	/**
 	 * delete logstore index
@@ -2077,8 +2040,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string parameter is empty
 	 */
-	public DeleteIndexResponse DeleteIndex(String project, String logStore)
-			throws LogException;
+    DeleteIndexResponse DeleteIndex(String project, String logStore) throws LogException;
 
 	/**
 	 * delete logstore index
@@ -2094,8 +2056,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteIndexResponse DeleteIndex(DeleteIndexRequest request)
-			throws LogException;
+    DeleteIndexResponse DeleteIndex(DeleteIndexRequest request) throws LogException;
 
 	/**
 	 * Get logstore index config
@@ -2113,10 +2074,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any string parameter is empty
 	 */
-	public GetIndexResponse GetIndex(String project, String logStore)
+    GetIndexResponse GetIndex(String project, String logStore)
 			throws LogException;
 
-    public GetIndexStringResponse GetIndexString(String project, String logStore)
+    GetIndexStringResponse GetIndexString(String project, String logStore)
             throws LogException;
 
 	/**
@@ -2133,11 +2094,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetIndexResponse GetIndex(GetIndexRequest request)
-			throws LogException;
+    GetIndexResponse GetIndex(GetIndexRequest request) throws LogException;
 
-    public GetIndexStringResponse GetIndexString(GetIndexRequest request)
-            throws LogException;
+    GetIndexStringResponse GetIndexString(GetIndexRequest request) throws LogException;
 
 	/**
 	 * create logstore consumer group
@@ -2153,8 +2112,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateConsumerGroupResponse CreateConsumerGroup(
-			CreateConsumerGroupRequest request) throws LogException;
+    CreateConsumerGroupResponse CreateConsumerGroup(CreateConsumerGroupRequest request)
+            throws LogException;
 
 	/**
 	 * create logstore consumer group
@@ -2174,8 +2133,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateConsumerGroupResponse CreateConsumerGroup(String project,
-			String logStore, ConsumerGroup consumerGroup) throws LogException;
+    CreateConsumerGroupResponse CreateConsumerGroup(String project,
+                                                    String logStore,
+                                                    ConsumerGroup consumerGroup) throws LogException;
 
 	/**
 	 * delete logstore consumer group
@@ -2195,8 +2155,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteConsumerGroupResponse DeleteConsumerGroup(String project,
-			String logStore, String consumerGroup) throws LogException;
+    DeleteConsumerGroupResponse DeleteConsumerGroup(String project,
+                                                    String logStore,
+                                                    String consumerGroup) throws LogException;
 
 	/**
 	 * list logstore consumer groups
@@ -2214,8 +2175,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListConsumerGroupResponse ListConsumerGroup(String project,
-			String logStore) throws LogException;
+    ListConsumerGroupResponse ListConsumerGroup(String project,
+                                                String logStore) throws LogException;
 
 	/**
 	 * update consumer group
@@ -2240,11 +2201,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateConsumerGroupResponse UpdateConsumerGroup(String project,
-			String logStore, String consumerGroup, boolean inOrder,
-			int timeoutInSec) throws LogException;
+    UpdateConsumerGroupResponse UpdateConsumerGroup(String project,
+                                                    String logStore, String consumerGroup, boolean inOrder,
+                                                    int timeoutInSec) throws LogException;
 
-	public UpdateConsumerGroupResponse
 	/**
 	 * update consumer group
 	 *
@@ -2265,8 +2225,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	UpdateConsumerGroup(String project, String logStore, String consumerGroup,
-			boolean inOrder) throws LogException;
+    UpdateConsumerGroupResponse UpdateConsumerGroup(String project,
+                                                    String logStore,
+                                                    String consumerGroup,
+                                                    boolean inOrder) throws LogException;
 
 	/**
 	 * update consumer group
@@ -2289,8 +2251,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateConsumerGroupResponse UpdateConsumerGroup(String project,
-			String logStore, String consumerGroup, int timeoutInSec)
+    UpdateConsumerGroupResponse UpdateConsumerGroup(String project,
+                                                    String logStore,
+                                                    String consumerGroup,
+                                                    int timeoutInSec)
 			throws LogException;
 
 	/**
@@ -2317,9 +2281,12 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ConsumerGroupUpdateCheckPointResponse UpdateCheckPoint(
-			String project, String logStore, String consumerGroup,
-			String consumer, int shard, String checkpoint) throws LogException;
+    ConsumerGroupUpdateCheckPointResponse UpdateCheckPoint(String project,
+                                                           String logStore,
+                                                           String consumerGroup,
+                                                           String consumer,
+                                                           int shard,
+                                                           String checkpoint) throws LogException;
 
 	/**
 	 * update consume checkpoint
@@ -2343,9 +2310,11 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ConsumerGroupUpdateCheckPointResponse UpdateCheckPoint(
-			String project, String logStore, String consumerGroup, int shard,
-			String checkpoint) throws LogException;
+    ConsumerGroupUpdateCheckPointResponse UpdateCheckPoint(String project,
+                                                           String logStore,
+                                                           String consumerGroup,
+                                                           int shard,
+                                                           String checkpoint) throws LogException;
 
 	/**
 	 * notify the server periodically to show that the consumer is still alive.
@@ -2369,9 +2338,11 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ConsumerGroupHeartBeatResponse HeartBeat(String project,
-			String logStore, String consumerGroup, String consumer,
-			ArrayList<Integer> shards) throws LogException;
+    ConsumerGroupHeartBeatResponse HeartBeat(String project,
+                                             String logStore,
+                                             String consumerGroup,
+                                             String consumer,
+                                             ArrayList<Integer> shards) throws LogException;
 
 	/**
 	 * get shard checkpoint in the consumer group
@@ -2393,8 +2364,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ConsumerGroupCheckPointResponse GetCheckPoint(String project,
-			String logStore, String consumerGroup, int shard)
+    ConsumerGroupCheckPointResponse GetCheckPoint(String project,
+                                                  String logStore,
+                                                  String consumerGroup,
+                                                  int shard)
 			throws LogException;
 
 	/**
@@ -2415,8 +2388,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ConsumerGroupCheckPointResponse GetCheckPoint(String project,
-			String logStore, String consumerGroup) throws LogException;
+    ConsumerGroupCheckPointResponse GetCheckPoint(String project,
+                                                  String logStore,
+                                                  String consumerGroup) throws LogException;
 
 	/**
 	 * create a shipper
@@ -2438,8 +2412,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateShipperResponse CreateShipper(String project, String logStore,
-			String shipperName, ShipperConfig shipConfig) throws LogException;
+    CreateShipperResponse CreateShipper(String project,
+                                        String logStore,
+                                        String shipperName,
+                                        ShipperConfig shipConfig) throws LogException;
 
 	/**
 	 * update a shipper
@@ -2462,8 +2438,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public UpdateShipperResponse UpdateShipper(String project, String logStore,
-			String shipperName, ShipperConfig shipConfig) throws LogException;
+    UpdateShipperResponse UpdateShipper(String project,
+                                        String logStore,
+                                        String shipperName,
+                                        ShipperConfig shipConfig) throws LogException;
 
 	/**
 	 * Delete a shipper
@@ -2484,8 +2462,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteShipperResponse DeleteShipper(String project, String logStore,
-			String ShipperName) throws LogException;
+    DeleteShipperResponse DeleteShipper(String project,
+                                        String logStore,
+                                        String ShipperName) throws LogException;
 
 	/**
 	 * Get a shipper config
@@ -2504,8 +2483,9 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetShipperResponse GetShipperConfig(String project, String logStore,
-			String shipperName) throws LogException;
+    GetShipperResponse GetShipperConfig(String project,
+                                        String logStore,
+                                        String shipperName) throws LogException;
 
 	/**
 	 * List shipper of a logstore
@@ -2522,8 +2502,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListShipperResponse ListShipper(String project, String logStore)
-			throws LogException;
+    ListShipperResponse ListShipper(String project, String logStore) throws LogException;
 
 	/**
 	 * Get the tasks of a logstore shipper
@@ -2553,9 +2532,14 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetShipperTasksResponse GetShipperTasks(String project,
-			String logStore, String shipperName, int startTime, int endTime,
-			String statusType, int offset, int size) throws LogException;
+    GetShipperTasksResponse GetShipperTasks(String project,
+                                            String logStore,
+                                            String shipperName,
+                                            int startTime,
+                                            int endTime,
+                                            String statusType,
+                                            int offset,
+                                            int size) throws LogException;
 
 	/**
 	 * retry the failed tasks, for every time it can only retry 10 task
@@ -2577,9 +2561,10 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public RetryShipperTasksResponse RetryShipperTasks(String project,
-			String logStore, String shipperName, List<String> taskList)
-			throws LogException;
+    RetryShipperTasksResponse RetryShipperTasks(String project,
+                                                String logStore,
+                                                String shipperName,
+                                                List<String> taskList) throws LogException;
 
 	/**
 	 * create a project
@@ -2597,8 +2582,8 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public CreateProjectResponse CreateProject(String project,
-			String projectDescription) throws LogException;
+    CreateProjectResponse CreateProject(String project,
+                                        String projectDescription) throws LogException;
 
 	/**
 	 * get a project
@@ -2613,7 +2598,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public GetProjectResponse GetProject(String project) throws LogException;
+    GetProjectResponse GetProject(String project) throws LogException;
 
 	/**
 	 * list project
@@ -2632,7 +2617,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListProjectResponse ListProject(String ProjectName, int offset, int size) throws LogException;
+    ListProjectResponse ListProject(String ProjectName, int offset, int size) throws LogException;
 
 	/**
 	 * list all project
@@ -2647,7 +2632,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public ListProjectResponse ListProject(ListProjectRequest request) throws LogException;
+    ListProjectResponse ListProject(ListProjectRequest request) throws LogException;
 
 	/**
 	 * delete a project
@@ -2662,8 +2647,7 @@ public interface LogService {
 	 * @throws IllegalArgumentException
 	 *             if any required string parameter is empty
 	 */
-	public DeleteProjectResponse DeleteProject(String project)
-			throws LogException;
+    DeleteProjectResponse DeleteProject(String project) throws LogException;
 
 	/**
 	 * list project


### PR DESCRIPTION
The ```public``` access modifier is not needed for methods in interface. Just remove it to make code shorter.