### PR TITLE
Remove StringBuilders as JVM will do it for us

### DIFF
--- a/src/main/java/com/aliyun/openservices/log/Client.java
+++ b/src/main/java/com/aliyun/openservices/log/Client.java
@@ -1068,10 +1068,7 @@ public class Client implements LogService {
 		String shardId = String.valueOf(request.GetShardId());
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shards/").append(shardId);
-		String resourceUri = resourceUriBuilder.toString();
+        String resourceUri = "/logstores/" + logStore + "/shards/" + shardId;
 
 		headParameter.put(Consts.CONST_CONTENT_LENGTH, String.valueOf(0));
 
@@ -1107,17 +1104,14 @@ public class Client implements LogService {
 		String shardId = String.valueOf(request.GetShardId());
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shards/").append(shardId);
-		String resourceUri = resourceUriBuilder.toString();
+        String resourceUri = "/logstores/" + logStore + "/shards/" + shardId;
 
 		headParameter.put(Consts.CONST_CONTENT_LENGTH, String.valueOf(0));
 
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = new ResponseMessage();
-		GetCursorTimeResponse getCursorTimeResponse = null;
+		GetCursorTimeResponse getCursorTimeResponse;
 		try {
 			response = SendData(project, HttpMethod.GET, resourceUri,
 					urlParameter, headParameter);
@@ -1178,13 +1172,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(midHash, "midHashKey");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shards/").append(shardId);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shards/" + shardId;
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.POST, resourceUri,
@@ -1218,12 +1206,7 @@ public class Client implements LogService {
 		int shardId = request.GetShardId();
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shards/").append(shardId);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shards/" + shardId;
 		Map<String, String> urlParameter = request.GetAllParams();
 
         ResponseMessage response = SendData(project, HttpMethod.POST, resourceUri,
@@ -1257,21 +1240,13 @@ public class Client implements LogService {
 		int shardId = request.GetShardId();
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shards/").append(shardId);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shards/" + shardId;
 		Map<String, String> urlParameter = request.GetAllParams();
 
         ResponseMessage response = SendData(project, HttpMethod.DELETE, resourceUri,
 				urlParameter, headParameter);
 		Map<String, String> resHeaders = response.getHeaders();
-
-		DeleteShardResponse res = new DeleteShardResponse(resHeaders);
-
-		return res;
+        return new DeleteShardResponse(resHeaders);
 	}
 
 	public ListShardResponse ListShard(String prj, String logStore)
@@ -1308,13 +1283,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(logStore, "logStore");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shards");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shards";
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.GET, resourceUri, urlParameter,
@@ -1367,14 +1336,8 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(shardId, "shardId");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shards/").append(shardId);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shards/" + shardId;
 		headParameter.put(Consts.CONST_ACCEPT_ENCODING, Consts.CONST_LZ4);
-
 		headParameter.put(Consts.CONST_HTTP_ACCEPT, Consts.CONST_PROTO_BUF);
 
 		Map<String, String> urlParameter = request.GetAllParams();
@@ -1468,12 +1431,7 @@ public class Client implements LogService {
 		byte[] body = encodeToUtf8(config.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/configs/").append(configName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/configs/" + configName;
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
         ResponseMessage response = SendData(project, HttpMethod.PUT, resourceUri, urlParameter,
@@ -1511,12 +1469,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(configName, "configName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/configs/").append(configName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/configs/" + configName;
 		Map<String, String> urlParameter = request.GetAllParams();
 
         ResponseMessage response = SendData(project, HttpMethod.GET, resourceUri, urlParameter,
@@ -1545,12 +1498,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(configName, "configName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/configs/").append(configName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/configs/" + configName;
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.DELETE,
@@ -1664,13 +1612,10 @@ public class Client implements LogService {
 		CodingUtils.assertParameterNotNull(group, "group");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
+        headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 		byte[] body = encodeToUtf8(group.ToRequestString());
 
-		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
-
 		String resourceUri = "/machinegroups";
-
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.POST,
@@ -1701,14 +1646,8 @@ public class Client implements LogService {
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
 		byte[] body = encodeToUtf8(group.ToRequestString());
-
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + groupName;
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.PUT,
@@ -1763,13 +1702,7 @@ public class Client implements LogService {
 		String groupName = request.GetGroupName();
 		CodingUtils.assertStringNotNullOrEmpty(groupName, "groupName");
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName)
-				.append("/configs");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + groupName + "/configs";
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.GET,
@@ -1798,13 +1731,7 @@ public class Client implements LogService {
 		String configName = request.GetConfigName();
 		CodingUtils.assertStringNotNullOrEmpty(configName, "groupName");
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/configs/").append(configName)
-				.append("/machinegroups");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/configs/" + configName + "/machinegroups";
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.GET,
@@ -1835,12 +1762,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(groupName, "groupName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + groupName;
 		Map<String, String> urlParameter = request.GetAllParams();
 		ResponseMessage response = SendData(project, HttpMethod.GET,
 				resourceUri, urlParameter, headParameter);
@@ -1861,13 +1783,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(machineGroup, "groupName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(machineGroup)
-				.append("/machines");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + machineGroup + "/machines";
 		headParameter.put(Consts.CONST_CONTENT_LENGTH, String.valueOf(0));
 
 		Map<String, String> urlParameter = new HashMap<String, String>();
@@ -1926,12 +1842,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(groupName, "groupName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName).append("/approve");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + groupName + "/approve";
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.PUT,
@@ -1960,12 +1871,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(groupName, "groupName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + groupName;
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.DELETE,
@@ -2080,12 +1986,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(configName, "configName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName)
-				.append("/configs/").append(configName);
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + groupName + "/configs/" + configName;
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.PUT,
@@ -2118,13 +2019,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(configName, "configName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName)
-				.append("/configs/").append(configName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/machinegroups/" + groupName + "/configs/" + configName;
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.DELETE,
@@ -2287,16 +2182,6 @@ public class Client implements LogService {
 		return listACLResponse;
 	}
 
-	@SuppressWarnings("unused")
-	private String ExtractJsonString(String nodeKey, JSONObject object) {
-		try {
-			return object.getString(nodeKey);
-		} catch (JSONException e) {
-			// ignore
-		}
-		return "";
-	}
-
 	private int ExtractJsonInteger(String nodeKey, JSONObject object) {
 		try {
 			return object.getInt(nodeKey);
@@ -2426,8 +2311,7 @@ public class Client implements LogService {
 		try {
 			JsonConfig jsonConfig = new JsonConfig();
 			jsonConfig.setIgnoreDefaultExcludes(true);
-			JSONArray array = JSONArray.fromObject(returnStr, jsonConfig);
-			return array;
+            return JSONArray.fromObject(returnStr, jsonConfig);
 		} catch (JSONException e) {
 			throw new LogException("BadResponse",
 					"The response is not valid json string : " + returnStr, e,
@@ -2741,12 +2625,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(logStoreName, "logStoreName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStoreName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStoreName;
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.DELETE,
@@ -2782,12 +2661,7 @@ public class Client implements LogService {
 		byte[] body = encodeToUtf8(logStore.ToRequestString());
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStoreName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStoreName;
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.PUT,
@@ -2828,12 +2702,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(logStoreName, "logStoreName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStoreName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStoreName;
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.GET,
@@ -2860,13 +2729,7 @@ public class Client implements LogService {
 
 		byte[] body = encodeToUtf8(indexJsonString);
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/index");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/index";
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.POST,
@@ -2902,11 +2765,7 @@ public class Client implements LogService {
 		byte[] body = encodeToUtf8(index.ToRequestString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/index");
-
-		String resourceUri = resourceUriBuilder.toString();
+        String resourceUri = "/logstores/" + logStore + "/index";
 
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
@@ -2931,13 +2790,7 @@ public class Client implements LogService {
 		byte[] body = encodeToUtf8(indexJsonString);
 
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/index");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/index";
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.PUT,
@@ -2972,13 +2825,7 @@ public class Client implements LogService {
 
 		byte[] body = encodeToUtf8(index.ToRequestString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/index");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/index";
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.PUT,
@@ -3007,13 +2854,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(logStore, "logStore");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/index");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/index";
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.DELETE,
@@ -3062,13 +2903,7 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(logStore, "logStore");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/index");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/index";
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = SendData(project, HttpMethod.GET,
@@ -3086,29 +2921,24 @@ public class Client implements LogService {
     @Override
     public GetIndexStringResponse GetIndexString(GetIndexRequest request)
                     throws LogException {
-            CodingUtils.assertParameterNotNull(request, "request");
-            String project = request.GetProject();
-            CodingUtils.assertStringNotNullOrEmpty(project, "project");
-            String logStore = request.GetLogStore();
-            CodingUtils.assertStringNotNullOrEmpty(logStore, "logStore");
+	    CodingUtils.assertParameterNotNull(request, "request");
+	    String project = request.GetProject();
+	    CodingUtils.assertStringNotNullOrEmpty(project, "project");
+	    String logStore = request.GetLogStore();
+	    CodingUtils.assertStringNotNullOrEmpty(logStore, "logStore");
 
-            Map<String, String> headParameter = GetCommonHeadPara(project);
+	    Map<String, String> headParameter = GetCommonHeadPara(project);
 
-            StringBuilder resourceUriBuilder = new StringBuilder();
-            resourceUriBuilder.append("/logstores/").append(logStore)
-                            .append("/index");
+        String resourceUri = "/logstores/" + logStore + "/index";
 
-            String resourceUri = resourceUriBuilder.toString();
+        Map<String, String> urlParameter = request.GetAllParams();
 
-            Map<String, String> urlParameter = request.GetAllParams();
+        ResponseMessage response = SendData(project, HttpMethod.GET,
+                resourceUri, urlParameter, headParameter);
 
-            ResponseMessage response = SendData(project, HttpMethod.GET,
-                            resourceUri, urlParameter, headParameter);
-
-            Map<String, String> resHeaders = response.getHeaders();
+        Map<String, String> resHeaders = response.getHeaders();
 
         return new GetIndexStringResponse(resHeaders, response.GetStringBody());
-
     }
 	
 	@Override
@@ -3120,31 +2950,22 @@ public class Client implements LogService {
 		CodingUtils.assertParameterNotNull(shipConfig, "shipConfig");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
+        headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shipper");
+        String resourceUri = "/logstores/" + logStore + "/shipper";
+		JSONObject jsonBody = new JSONObject();
+        jsonBody.put("shipperName", shipperName);
+        jsonBody.put("targetType", shipConfig.GetShipperType());
+        jsonBody.put("targetConfiguration", shipConfig.GetJsonObj());
 
-		String resourceUri = resourceUriBuilder.toString();
-
-		JSONObject json_body = new JSONObject();
-		json_body.put("shipperName", shipperName);
-		json_body.put("targetType", shipConfig.GetShipperType());
-		json_body.put("targetConfiguration", shipConfig.GetJsonObj());
-
-		byte[] body = encodeToUtf8(json_body.toString());
-		
-		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
+		byte[] body = encodeToUtf8(jsonBody.toString());
 
 		Map<String, String> urlParameter = new HashMap<String, String>();
-
 		ResponseMessage response = SendData(project, HttpMethod.POST,
 				resourceUri, urlParameter, headParameter, body);
 
 		Map<String, String> resHeaders = response.getHeaders();
-
 		return new CreateShipperResponse(resHeaders);
-
 	}
 
 	@Override
@@ -3157,19 +2978,13 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shipper/").append(shipperName);
+        String resourceUri = "/logstores/" + logStore + "/shipper/" + shipperName;
+		JSONObject jsonBody = new JSONObject();
+        jsonBody.put("shipperName", shipperName);
+        jsonBody.put("targetType", shipConfig.GetShipperType());
+        jsonBody.put("targetConfiguration", shipConfig.GetJsonObj());
 
-		String resourceUri = resourceUriBuilder.toString();
-
-		JSONObject json_body = new JSONObject();
-		json_body.put("shipperName", shipperName);
-		json_body.put("targetType", shipConfig.GetShipperType());
-		json_body.put("targetConfiguration", shipConfig.GetJsonObj());
-
-		byte[] body = encodeToUtf8(json_body.toString());
-
+		byte[] body = encodeToUtf8(jsonBody.toString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		Map<String, String> urlParameter = new HashMap<String, String>();
@@ -3178,7 +2993,6 @@ public class Client implements LogService {
 				resourceUri, urlParameter, headParameter, body);
 
 		Map<String, String> resHeaders = response.getHeaders();
-
 		return new UpdateShipperResponse(resHeaders);
 	}
 
@@ -3190,20 +3004,13 @@ public class Client implements LogService {
 		CodingUtils.assertParameterNotNull(shipperName, "shipperName");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shipper/").append(shipperName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shipper/" + shipperName;
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.DELETE,
 				resourceUri, urlParameter, headParameter);
 
 		Map<String, String> resHeaders = response.getHeaders();
-
 		return new DeleteShipperResponse(resHeaders);
 	}
 
@@ -3216,14 +3023,8 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shipper/").append(shipperName);
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shipper/" + shipperName;
 		Map<String, String> urlParameter = new HashMap<String, String>();
-
 		ResponseMessage response = SendData(project, HttpMethod.GET,
 				resourceUri, urlParameter, headParameter);
 
@@ -3256,14 +3057,8 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shipper");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shipper";
 		Map<String, String> urlParameter = new HashMap<String, String>();
-
 		ResponseMessage response = SendData(project, HttpMethod.GET,
 				resourceUri, urlParameter, headParameter);
 
@@ -3288,12 +3083,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shipper/").append(shipperName).append("/tasks");
-
-		String resourceUri = resourceUriBuilder.toString();
-
+        String resourceUri = "/logstores/" + logStore + "/shipper/" + shipperName + "/tasks";
 		Map<String, String> urlParameter = new HashMap<String, String>();
 		urlParameter.put("from", String.valueOf(startTime));
 		urlParameter.put("to", String.valueOf(endTime));
@@ -3323,11 +3113,7 @@ public class Client implements LogService {
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/shipper/").append(shipperName).append("/tasks");
-
-		String resourceUri = resourceUriBuilder.toString();
+        String resourceUri = "/logstores/" + logStore + "/shipper/" + shipperName + "/tasks";
 
 		JSONArray array = new JSONArray();
 		for (String task : taskList) {
@@ -3400,7 +3186,6 @@ public class Client implements LogService {
 
 		Map<String, String> resHeaders = response.getHeaders();
 		return new CreateConsumerGroupResponse(resHeaders);
-
 	}
 
 	protected UpdateConsumerGroupResponse UpdateConsumerGroup(String project,
@@ -3429,7 +3214,6 @@ public class Client implements LogService {
 
 		Map<String, String> resHeaders = response.getHeaders();
 		return new UpdateConsumerGroupResponse(resHeaders);
-
 	}
 
 	public UpdateConsumerGroupResponse UpdateConsumerGroup(String project,
@@ -3460,10 +3244,7 @@ public class Client implements LogService {
 		CodingUtils.assertParameterNotNull(logStore, "logStore");
 		CodingUtils.assertStringNotNullOrEmpty(consumerGroup, "consumerGroup");
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/logstores/").append(logStore)
-				.append("/consumergroups/").append(consumerGroup);
-		String resourceUri = resourceUriBuilder.toString();
+        String resourceUri = "/logstores/" + logStore + "/consumergroups/" + consumerGroup;
 		headParameter.put(Consts.CONST_CONTENT_LENGTH, String.valueOf(0));
 
 		Map<String, String> urlParameter = new HashMap<String, String>();
@@ -3472,9 +3253,7 @@ public class Client implements LogService {
 				resourceUri, urlParameter, headParameter);
 
 		Map<String, String> resHeaders = response.getHeaders();
-
 		return new DeleteConsumerGroupResponse(resHeaders);
-
 	}
 
 	public ListConsumerGroupResponse ListConsumerGroup(String project,
@@ -3592,7 +3371,6 @@ public class Client implements LogService {
 		ExtractShards(array, requestId, responseShards);
 
 		return new ConsumerGroupHeartBeatResponse(resHeaders, responseShards);
-
 	}
 
 	protected void ExtractShards(JSONArray array, String requestId,
@@ -3634,9 +3412,7 @@ public class Client implements LogService {
 		String requestId = GetRequestId(resHeaders);
 
 		JSONArray array = ParseResponseMessageToArray(response, requestId);
-		ConsumerGroupCheckPointResponse consumerGroupCheckPointResponse = new ConsumerGroupCheckPointResponse(
-				resHeaders, array);
-		return consumerGroupCheckPointResponse;
+        return new ConsumerGroupCheckPointResponse(resHeaders, array);
 	}
 
 	@Override
@@ -3651,12 +3427,11 @@ public class Client implements LogService {
 
 		String resourceUri = "/";
 
-		JSONObject json_body = new JSONObject();
-		json_body.put("projectName", project);
-		json_body.put("description", projectDescription);
+		JSONObject jsonBody = new JSONObject();
+        jsonBody.put("projectName", project);
+        jsonBody.put("description", projectDescription);
 
-		byte[] body = encodeToUtf8(json_body.toString());
-
+		byte[] body = encodeToUtf8(jsonBody.toString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
 		Map<String, String> urlParameter = new HashMap<String, String>();
@@ -3665,7 +3440,6 @@ public class Client implements LogService {
 				resourceUri, urlParameter, headParameter, body);
 
 		Map<String, String> resHeaders = response.getHeaders();
-
 		return new CreateProjectResponse(resHeaders);
 	}
 
@@ -3675,18 +3449,14 @@ public class Client implements LogService {
 		CodingUtils.assertStringNotNullOrEmpty(project, "project");
 
 		Map<String, String> headParameter = GetCommonHeadPara(project);
-
 		String resourceUri = "/";
-
 		Map<String, String> urlParameter = new HashMap<String, String>();
 
 		ResponseMessage response = SendData(project, HttpMethod.GET,
 				resourceUri, urlParameter, headParameter);
 
 		Map<String, String> resHeaders = response.getHeaders();
-
-		GetProjectResponse getProjectResponse = new GetProjectResponse(
-				resHeaders);
+		GetProjectResponse getProjectResponse = new GetProjectResponse(resHeaders);
 		String requestId = GetRequestId(resHeaders);
 		JSONObject object = ParserResponseMessage(response, requestId);
 		getProjectResponse.FromJsonObject(object);
@@ -3700,16 +3470,12 @@ public class Client implements LogService {
 
 		String resourceUri = "/";
 		Map<String, String> urlParameter = new HashMap<String, String>();
-
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
 		ResponseMessage response = SendData(project, HttpMethod.DELETE,
 				resourceUri, urlParameter, headParameter);
-
 		Map<String, String> resHeaders = response.getHeaders();
-
 		return new DeleteProjectResponse(resHeaders);
-
 	}
 
 	@Override
@@ -3751,11 +3517,7 @@ public class Client implements LogService {
 		byte[] body = encodeToUtf8(machineList.ToRequestString());
 		headParameter.put(Consts.CONST_CONTENT_TYPE, Consts.CONST_SLS_JSON);
 
-		StringBuilder resourceUriBuilder = new StringBuilder();
-		resourceUriBuilder.append("/machinegroups/").append(groupName)
-				.append("/machines");
-
-		String resourceUri = resourceUriBuilder.toString();
+        String resourceUri = "/machinegroups/" + groupName + "/machines";
 
 		Map<String, String> urlParameter = new HashMap<String, String>();
 		if (isDelete) // delete machine from machine group
@@ -3809,7 +3571,6 @@ public class Client implements LogService {
 		Map<String, String> headParameter = GetCommonHeadPara(project);
 
 		String resourceUri = "/";
-
 		Map<String, String> urlParameter = request.GetAllParams();
 
 		ResponseMessage response = new ResponseMessage();


### PR DESCRIPTION
We do not need to concat a few strings using ```StringBuilder``` manually. It's the default behavior of JVM. Just replace it with native string concatenation.  